### PR TITLE
Disable auth and CSRF

### DIFF
--- a/wolf_llm_backend/config/settings.py
+++ b/wolf_llm_backend/config/settings.py
@@ -45,8 +45,9 @@ MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    # CSRFと認証を無効化
+    # 'django.middleware.csrf.CsrfViewMiddleware',
+    # 'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
@@ -122,3 +123,9 @@ STATIC_URL = 'static/'
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+# REST frameworkの認証とパーミッションを無効化
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': [],
+    'DEFAULT_PERMISSION_CLASSES': [],
+}


### PR DESCRIPTION
## Summary
- disable CSRF and auth middleware
- turn off REST framework auth defaults

## Testing
- `python -m py_compile wolf_llm_backend/config/settings.py`

------
https://chatgpt.com/codex/tasks/task_e_684f096ac0bc83208da524ca397a5a7a